### PR TITLE
Apply all market data review fixes (items 1-6)

### DIFF
--- a/backend/app/market/cache.py
+++ b/backend/app/market/cache.py
@@ -60,6 +60,7 @@ class PriceCache:
         """Remove a ticker from the cache (e.g., when removed from watchlist)."""
         with self._lock:
             self._prices.pop(ticker, None)
+            self._version += 1
 
     @property
     def version(self) -> int:

--- a/backend/app/market/massive_client.py
+++ b/backend/app/market/massive_client.py
@@ -69,7 +69,8 @@ class MassiveDataSource(MarketDataSource):
         ticker = ticker.upper().strip()
         if ticker not in self._tickers:
             self._tickers.append(ticker)
-            logger.info("Massive: added ticker %s (will appear on next poll)", ticker)
+            await self._poll_once(tickers=[ticker])  # seed cache immediately
+            logger.info("Massive: added ticker %s", ticker)
 
     async def remove_ticker(self, ticker: str) -> None:
         ticker = ticker.upper().strip()
@@ -88,15 +89,21 @@ class MassiveDataSource(MarketDataSource):
             await asyncio.sleep(self._interval)
             await self._poll_once()
 
-    async def _poll_once(self) -> None:
-        """Execute one poll cycle: fetch snapshots, update cache."""
-        if not self._tickers or not self._client:
+    async def _poll_once(self, tickers: list[str] | None = None) -> None:
+        """Execute one poll cycle: fetch snapshots, update cache.
+
+        Args:
+            tickers: Optional override list of tickers to fetch. If None,
+                     uses self._tickers (the full watchlist).
+        """
+        active_tickers = tickers if tickers is not None else self._tickers
+        if not active_tickers or not self._client:
             return
 
         try:
             # The Massive RESTClient is synchronous — run in a thread to
             # avoid blocking the event loop.
-            snapshots = await asyncio.to_thread(self._fetch_snapshots)
+            snapshots = await asyncio.to_thread(self._fetch_snapshots, active_tickers)
             processed = 0
             for snap in snapshots:
                 try:
@@ -115,18 +122,18 @@ class MassiveDataSource(MarketDataSource):
                         getattr(snap, "ticker", "???"),
                         e,
                     )
-            logger.debug("Massive poll: updated %d/%d tickers", processed, len(self._tickers))
+            logger.debug("Massive poll: updated %d/%d tickers", processed, len(active_tickers))
 
         except Exception as e:
             logger.error("Massive poll failed: %s", e)
             # Don't re-raise — the loop will retry on the next interval.
             # Common failures: 401 (bad key), 429 (rate limit), network errors.
 
-    def _fetch_snapshots(self) -> list:
+    def _fetch_snapshots(self, tickers: list[str]) -> list:
         """Synchronous call to the Massive REST API. Runs in a thread."""
         from massive.rest.models import SnapshotMarketType
 
         return self._client.get_snapshot_all(
             market_type=SnapshotMarketType.STOCKS,
-            tickers=self._tickers,
+            tickers=tickers,
         )

--- a/backend/app/market/seed_prices.py
+++ b/backend/app/market/seed_prices.py
@@ -44,4 +44,8 @@ CORRELATION_GROUPS: dict[str, set[str]] = {
 INTRA_TECH_CORR = 0.6  # Tech stocks move together
 INTRA_FINANCE_CORR = 0.5  # Finance stocks move together
 CROSS_GROUP_CORR = 0.3  # Between sectors / unknown tickers
-TSLA_CORR = 0.3  # TSLA does its own thing
+# TSLA is intentionally handled as a special case in _pairwise_correlation,
+# checked before the sector groups. Although TSLA_CORR == CROSS_GROUP_CORR == 0.3,
+# the separate constant documents intent: TSLA is treated as an independent,
+# high-volatility outlier regardless of which tickers it is paired with.
+TSLA_CORR = 0.3

--- a/backend/app/market/stream.py
+++ b/backend/app/market/stream.py
@@ -81,6 +81,8 @@ async def _generate_events(
                     data = {ticker: update.to_dict() for ticker, update in prices.items()}
                     payload = json.dumps(data)
                     yield f"data: {payload}\n\n"
+            else:
+                yield ": keepalive\n\n"
 
             await asyncio.sleep(interval)
     except asyncio.CancelledError:

--- a/backend/tests/market/test_simulator.py
+++ b/backend/tests/market/test_simulator.py
@@ -45,7 +45,7 @@ class TestGBMSimulator:
         """Test that adding a duplicate ticker is a no-op."""
         sim = GBMSimulator(tickers=["AAPL"])
         sim.add_ticker("AAPL")
-        assert len(sim._tickers) == 1
+        assert sim.get_tickers() == ["AAPL"]
 
     def test_remove_nonexistent_is_noop(self):
         """Test that removing a non-existent ticker is a no-op."""
@@ -77,17 +77,17 @@ class TestGBMSimulator:
         # Price should have changed (extremely unlikely to be exactly the seed)
         assert final_price != initial_price
 
-    def test_cholesky_rebuilds_on_add(self):
-        """Test that Cholesky matrix is rebuilt when tickers are added."""
-        sim = GBMSimulator(tickers=["AAPL"])
-        assert sim._cholesky is None  # Only 1 ticker, no correlation matrix
-        sim.add_ticker("GOOGL")
-        assert sim._cholesky is not None  # Now 2 tickers, matrix exists
+    def test_cholesky_active_with_multiple_tickers(self):
+        """With 2+ tickers, correlated moves are produced (step doesn't crash)."""
+        sim = GBMSimulator(tickers=["AAPL", "GOOGL"])
+        prices = sim.step()
+        assert len(prices) == 2  # both updated, correlation matrix worked
 
-    def test_cholesky_none_with_one_ticker(self):
-        """Test that Cholesky is None with only one ticker."""
+    def test_cholesky_inactive_with_one_ticker(self):
+        """With a single ticker, step() still produces a price (no correlation needed)."""
         sim = GBMSimulator(tickers=["AAPL"])
-        assert sim._cholesky is None
+        prices = sim.step()
+        assert len(prices) == 1
 
     def test_get_price_returns_none_for_unknown(self):
         """Test that get_price returns None for unknown ticker."""

--- a/backend/tests/market/test_stream.py
+++ b/backend/tests/market/test_stream.py
@@ -1,0 +1,137 @@
+"""Tests for the SSE streaming generator (_generate_events)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.market.cache import PriceCache
+from app.market.stream import _generate_events
+
+
+def _make_request(disconnected_sequence: list[bool]) -> AsyncMock:
+    """Build a mock FastAPI Request.
+
+    disconnected_sequence: list of return values for successive
+    is_disconnected() calls. The generator checks once per loop
+    iteration, so the final True causes it to break.
+    """
+    request = AsyncMock()
+    request.client = None  # Avoids AttributeError on request.client.host
+    request.is_disconnected = AsyncMock(side_effect=disconnected_sequence)
+    return request
+
+
+async def _collect(cache: PriceCache, request: AsyncMock, max_events: int = 20) -> list[str]:
+    """Collect up to max_events from _generate_events."""
+    events: list[str] = []
+    async for event in _generate_events(cache, request, interval=0.001):
+        events.append(event)
+        if len(events) >= max_events:
+            break
+    return events
+
+
+@pytest.mark.asyncio
+class TestGenerateEvents:
+    async def test_retry_directive_is_first_event(self):
+        """The first yielded event must be the SSE retry directive."""
+        cache = PriceCache()
+        request = _make_request([False, True])
+
+        events = await _collect(cache, request)
+
+        assert events[0] == "retry: 1000\n\n"
+
+    async def test_price_event_emitted_on_cache_update(self):
+        """A data event is sent when the cache has content and the version changed."""
+        cache = PriceCache()
+        cache.update("AAPL", 190.50)
+        request = _make_request([False, True])
+
+        events = await _collect(cache, request)
+
+        data_events = [e for e in events if e.startswith("data:")]
+        assert len(data_events) == 1
+        payload = json.loads(data_events[0].removeprefix("data: ").strip())
+        assert "AAPL" in payload
+        assert payload["AAPL"]["price"] == 190.50
+
+    async def test_empty_cache_sends_no_data_event(self):
+        """When the cache is empty, no data: event should be emitted."""
+        cache = PriceCache()
+        request = _make_request([False, True])
+
+        events = await _collect(cache, request)
+
+        data_events = [e for e in events if e.startswith("data:")]
+        assert data_events == []
+
+    async def test_keepalive_sent_when_no_change(self):
+        """When the cache version is unchanged, a keepalive comment is yielded."""
+        cache = PriceCache()
+        cache.update("AAPL", 190.00)
+
+        # First iteration: version changed → data event
+        # Second iteration: version unchanged → keepalive
+        # Third iteration: disconnect
+        request = _make_request([False, False, True])
+
+        events = await _collect(cache, request)
+
+        keepalives = [e for e in events if e == ": keepalive\n\n"]
+        assert len(keepalives) >= 1
+
+    async def test_disconnect_terminates_generator(self):
+        """Generator should stop cleanly when client disconnects."""
+        cache = PriceCache()
+        request = _make_request([True])  # Disconnect on the very first check
+
+        events = await _collect(cache, request)
+
+        # Only the initial retry directive is yielded before the loop starts
+        assert events == ["retry: 1000\n\n"]
+
+    async def test_multiple_tickers_in_event(self):
+        """All tickers in the cache appear in a single SSE data event."""
+        cache = PriceCache()
+        cache.update("AAPL", 190.00)
+        cache.update("GOOGL", 175.00)
+        request = _make_request([False, True])
+
+        events = await _collect(cache, request)
+
+        data_events = [e for e in events if e.startswith("data:")]
+        assert len(data_events) == 1
+        payload = json.loads(data_events[0].removeprefix("data: ").strip())
+        assert "AAPL" in payload
+        assert "GOOGL" in payload
+
+    async def test_cache_removal_triggers_event(self):
+        """Removing a ticker bumps the cache version and triggers a new data event."""
+        cache = PriceCache()
+        cache.update("AAPL", 190.00)
+        cache.update("GOOGL", 175.00)
+
+        # Allow three loop iterations: first sends both tickers,
+        # then we remove GOOGL (bumping version), second sends only AAPL.
+        request = _make_request([False, False, True])
+
+        events: list[str] = []
+        iteration = 0
+        async for event in _generate_events(cache, request, interval=0.001):
+            events.append(event)
+            # After the first data event, remove GOOGL so version bumps
+            if event.startswith("data:") and iteration == 0:
+                cache.remove("GOOGL")
+                iteration += 1
+            if len(events) >= 10:
+                break
+
+        data_events = [e for e in events if e.startswith("data:")]
+        assert len(data_events) >= 2
+        last_payload = json.loads(data_events[-1].removeprefix("data: ").strip())
+        assert "GOOGL" not in last_payload
+        assert "AAPL" in last_payload


### PR DESCRIPTION
- cache.py: increment version in remove() so SSE pushes on ticker removal
- stream.py: yield ': keepalive\n\n' when cache is unchanged (fixes proxy idle timeout)
- massive_client.py: add_ticker now calls _poll_once([ticker]) immediately to seed cache; _poll_once/fetch_snapshots accept optional tickers override
- test_simulator.py: replace private _cholesky/_tickers assertions with observable-behaviour tests
- test_stream.py: new — covers _generate_events (retry directive, data events, keepalive, empty cache, disconnect, multi-ticker, removal trigger)
- seed_prices.py: add comment clarifying TSLA_CORR vs CROSS_GROUP_CORR intent